### PR TITLE
Broken CSS because of new article tag

### DIFF
--- a/app/controllers/currencies.picker.coffee
+++ b/app/controllers/currencies.picker.coffee
@@ -9,7 +9,7 @@ class CurrenciesPicker extends Panel
     'currenciesPicker list'
   
   events:
-    'tap .content .item': 'click'
+    'tap article .item': 'click'
   
   constructor: (@controller, @callback) ->
     super()

--- a/css/views/currencies.picker.styl
+++ b/css/views/currencies.picker.styl
@@ -21,7 +21,7 @@
       left: 0
       top: 0      
       
-  .content 
+  article
     background: #f0f0f0
     
     &:empty:after

--- a/css/views/currencies.styl
+++ b/css/views/currencies.styl
@@ -1,4 +1,4 @@
-.currencies .content
+.currencies article
   .status
     margin: 0.5em 0em
     font-size: 1.8em


### PR DESCRIPTION
Using "hem server" the result looks like this: http://imageshack.us/photo/my-images/6/bildschirmfoto20110921u.png/
The already compiled version looks fine.

Comparing the HTML to the example hosted on heroku I noticed the following difference:
Heroku version:
The section elements (status, input, flip, output, pad) are wrapped in a div with class="content"

Github version:
The sections are wrapped in an article tag
