### PR TITLE
Desktop compatibility

### DIFF
--- a/app/controllers/currencies.coffee
+++ b/app/controllers/currencies.coffee
@@ -8,9 +8,9 @@ class Currencies extends Panel
     'currencies'
     
   events:
-    'touchstart .pad div': 'enter'
-    'touchstart .pad .clear': 'clear'
-    'touchstart .pad .point': 'point'
+    'tap .pad div': 'enter'
+    'tap .pad .clear': 'clear'
+    'tap .pad .point': 'point'
     'tap .input': 'changeFrom'
     'tap .output': 'changeTo'
     'tap .flip': 'flip'

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "app",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "dependencies": { 
-    "ace": "~0.0.1",
-    "hem": "~0.0.6",
+    "serveup": "~0.0.2",
+    "hem": "~0.1.6",
     "es5-shimify": "~0.0.1",
     "json2ify": "~0.0.1",
     "jqueryify": "~0.0.1",
-    "gfx": "~0.0.3",
-    "spine": "latest",
-    "spine.mobile": "latest"
+    "spine": "~1.0.5",
+    "spine.mobile": "~1.0.0",
+    "gfx": "~0.0.4"
   }
 }


### PR DESCRIPTION
Hi Alex,
When I was trying this out, I noticed that I couldn't click on the number buttons.  This is because I was testing it on my laptop and the touchstart event was not being triggered.  I have changed these to tap events, since these get downgraded to click events on a non-touch screen.
Also to get the thing working on my machine, I had to change the dependencies - getting rid of ace and changing to serveup - based on those in the skeleton app generated by the "spine mobile xxx" command.
Cheers,
Pete
